### PR TITLE
Don't swallow errors without logging them

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -198,7 +198,8 @@ func writeResultToFile(filename string, results []results.Result) (err error) {
 	log.Debug("entering writeResultToFile function")
 	file, err := os.Create(filename)
 	if err != nil {
-		return fmt.Errorf("failed to open output file: %s", filename)
+		log.WithError(err).Errorf("failed to open output file: %s", filename)
+		return err
 	}
 	defer func() {
 		closeErr := file.Close()
@@ -208,11 +209,13 @@ func writeResultToFile(filename string, results []results.Result) (err error) {
 	}()
 	output, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal results: %s", err)
+		log.WithError(err).Errorf("failed to marshal results: %s", err)
+		return err
 	}
 	_, err = file.Write(output)
 	if err != nil {
-		return fmt.Errorf("failed to write results to file: %s", err)
+		log.WithError(err).Errorf("failed to write results to file: %s", err)
+		return err
 	}
 	return nil
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -61,8 +61,7 @@ func ConfigureCluster(ctx context.Context, cfg config.Config, clients config.Cli
 	} else if testConfig.Dataplane == config.DataPlaneUnset {
 		log.Info("No dataplane specified, using whatever is already set")
 	} else {
-		log.WithError(err).Errorf("invalid dataplane requested: %s", testConfig.Dataplane)
-		return err
+		return fmt.Errorf("invalid dataplane requested: %s", testConfig.Dataplane)
 	}
 
 	if testConfig.TestKind == config.TestKindDNSPerf {

--- a/pkg/cluster/cluster_internal.go
+++ b/pkg/cluster/cluster_internal.go
@@ -16,7 +16,6 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -44,7 +43,8 @@ func enableBPF(ctx context.Context, cfg config.Config, clients config.Clients) e
 	defer cancel()
 	err := clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Name: "default"}, installation)
 	if err != nil {
-		return fmt.Errorf("failed to get installation")
+		log.WithError(err).Error("failed to get installation")
+		return err
 	}
 	if *installation.Spec.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneBPF {
 		log.Info("BPF already enabled")
@@ -57,7 +57,8 @@ func enableBPF(ctx context.Context, cfg config.Config, clients config.Clients) e
 		kubesvc := &corev1.Endpoints{}
 		err := clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Name: "kubernetes", Namespace: "default"}, kubesvc)
 		if err != nil {
-			return fmt.Errorf("failed to get kubernetes service endpoints")
+			log.WithError(err).Error("failed to get kubernetes service endpoints")
+			return err
 		}
 		log.Infof("first kubernetes service endpoint IP is %v", kubesvc.Subsets[0].Addresses[0].IP)
 		log.Infof("first kubernetes service endpoint port is %v", kubesvc.Subsets[0].Ports[0].Port)
@@ -71,7 +72,8 @@ func enableBPF(ctx context.Context, cfg config.Config, clients config.Clients) e
 	// if it doesn't exist already, create configMap with k8s endpoint data in it
 	err = createOrUpdateCM(childCtx, clients, host, port)
 	if err != nil {
-		return fmt.Errorf("failed to create or update configMap")
+		log.WithError(err).Error("failed to create or update configMap")
+		return err
 	}
 
 	// kubectl patch ds -n kube-system kube-proxy -p '{"spec":{"template":{"spec":{"nodeSelector":{"non-calico": "true"}}}}}'
@@ -80,13 +82,15 @@ func enableBPF(ctx context.Context, cfg config.Config, clients config.Clients) e
 	log.Debug("Getting kube-proxy ds")
 	err = clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Namespace: "kube-system", Name: "kube-proxy"}, proxyds)
 	if err != nil {
-		return fmt.Errorf("failed to get kube-proxy ds")
+		log.WithError(err).Error("failed to get kube-proxy ds")
+		return err
 	}
 	log.Debugf("patching with %v", string(patch[:]))
 	log.Info("enabling BPF dataplane")
 	err = clients.CtrlClient.Patch(childCtx, proxyds, ctrlclient.RawPatch(ctrlclient.Merge.Type(), patch))
 	if err != nil {
-		return fmt.Errorf("failed to patch kube-proxy ds")
+		log.WithError(err).Error("failed to patch kube-proxy ds")
+		return err
 	}
 
 	// kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
@@ -96,16 +100,19 @@ func enableBPF(ctx context.Context, cfg config.Config, clients config.Clients) e
 	log.Debug("Getting installation")
 	err = clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Name: "default"}, installation)
 	if err != nil {
-		return fmt.Errorf("failed to get installation")
+		log.WithError(err).Error("failed to get installation")
+		return err
 	}
 	log.Debugf("patching with %v", string(patch[:]))
 	err = clients.CtrlClient.Patch(childCtx, installation, ctrlclient.RawPatch(ctrlclient.Merge.Type(), patch))
 	if err != nil {
-		return fmt.Errorf("failed to patch installation")
+		log.WithError(err).Error("failed to patch installation")
+		return err
 	}
 	err = waitForTigeraStatus(ctx, clients)
 	if err != nil {
-		return fmt.Errorf("error waiting for tigera status")
+		log.WithError(err).Error("error waiting for tigera status")
+		return err
 	}
 	return nil
 }
@@ -119,7 +126,8 @@ func enableIptables(ctx context.Context, clients config.Clients) error {
 	log.Debug("Getting installation")
 	err := clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Name: "default"}, installation)
 	if err != nil {
-		return fmt.Errorf("failed to get installation")
+		log.WithError(err).Error("failed to get installation")
+		return err
 	}
 	if *installation.Spec.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneIptables {
 		log.Info("IPtables already enabled")
@@ -133,13 +141,15 @@ func enableIptables(ctx context.Context, clients config.Clients) error {
 	log.Debug("Getting installation")
 	err = clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Name: "default"}, installation)
 	if err != nil {
-		return fmt.Errorf("failed to get installation")
+		log.WithError(err).Error("failed to get installation")
+		return err
 	}
 	log.Debugf("patching with %v", string(patch[:]))
 	log.Info("enabling iptables dataplane")
 	err = clients.CtrlClient.Patch(childCtx, installation, ctrlclient.RawPatch(ctrlclient.Merge.Type(), patch))
 	if err != nil {
-		return fmt.Errorf("failed to patch installation")
+		log.WithError(err).Error("failed to patch installation")
+		return err
 	}
 
 	// kubectl patch ds -n kube-system kube-proxy --type merge -p '{"spec":{"template":{"spec":{"nodeSelector":{"non-calico": null}}}}}'
@@ -148,17 +158,20 @@ func enableIptables(ctx context.Context, clients config.Clients) error {
 	log.Debug("Getting kube-proxy ds")
 	err = clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Namespace: "kube-system", Name: "kube-proxy"}, proxyds)
 	if err != nil {
-		return fmt.Errorf("failed to get kube-proxy ds")
+		log.WithError(err).Error("failed to get kube-proxy ds")
+		return err
 	}
 	log.Debugf("patching with %v", string(patch[:]))
 	err = clients.CtrlClient.Patch(childCtx, proxyds, ctrlclient.RawPatch(ctrlclient.Merge.Type(), patch))
 	if err != nil {
-		return fmt.Errorf("failed to patch kube-proxy ds")
+		log.WithError(err).Error("failed to patch kube-proxy ds")
+		return err
 	}
 
 	err = waitForTigeraStatus(ctx, clients)
 	if err != nil {
-		return fmt.Errorf("error waiting for tigera status")
+		log.WithError(err).Error("error waiting for tigera status")
+		return err
 	}
 	return nil
 }
@@ -208,11 +221,13 @@ func waitForTigeraStatus(ctx context.Context, clients config.Clients) error {
 		time.Sleep(10 * time.Second)
 		err := clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Name: "apiserver"}, apiStatus)
 		if err != nil {
-			return fmt.Errorf("failed to get apiserver status")
+			log.WithError(err).Error("failed to get apiserver status")
+			return err
 		}
 		err = clients.CtrlClient.Get(childCtx, ctrlclient.ObjectKey{Name: "calico"}, calicoStatus)
 		if err != nil {
-			return fmt.Errorf("failed to get calico status")
+			log.WithError(err).Error("failed to get calico status")
+			return err
 		}
 		for _, apiCondition := range apiStatus.Status.Conditions {
 			log.Debugf("apiserver condition: %v", apiCondition)
@@ -243,38 +258,44 @@ func updateEncap(ctx context.Context, cfg config.Config, clients config.Clients,
 		patch = []byte(`{"spec":{"ipipMode":"Never","vxlanMode":"Never"}}`)
 		err = patchInstallation(ctx, clients, "None")
 		if err != nil {
-			return fmt.Errorf("failed to patch installation")
+			log.WithError(err).Error("failed to patch installation")
+			return err
 		}
 	} else if encap == config.EncapIPIP {
 		// kubectl patch ippool default-ipv4-ippool -p '{"spec": {"ipipMode": "Always"}, {vxlanMode: "Never"}}'
 		patch = []byte(`{"spec":{"ipipMode":"Always","vxlanMode":"Never"}}`)
 		err = patchInstallation(ctx, clients, "IPIP")
 		if err != nil {
-			return fmt.Errorf("failed to patch installation")
+			log.WithError(err).Error("failed to patch installation")
+			return err
 		}
 	} else if encap == config.EncapVXLAN {
 		// kubectl patch ippool default-ipv4-ippool -p '{"spec": {"ipipMode": "Never"}, {vxlanMode: "Always"}}'
 		patch = []byte(`{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}`)
 		err = patchInstallation(ctx, clients, "VXLAN")
 		if err != nil {
-			return fmt.Errorf("failed to patch installation")
+			log.WithError(err).Error("failed to patch installation")
+			return err
 		}
 	} else if encap == config.EncapUnset {
 		log.Info("No encapsulation specified, using whatever is already set")
 	} else {
-		return fmt.Errorf("invalid encapsulation %s", encap)
+		log.WithError(err).Errorf("invalid encapsulation %s", encap)
+		return err
 	}
 
 	if semver.Compare(cfg.CalicoVersion, "v3.28.0") < 0 {
 		log.Debug("Calico version is less than v3.28.0, patching IPPool")
 		err = patchIPPool(ctx, clients, patch)
 		if err != nil {
-			return fmt.Errorf("failed to patch IPPool")
+			log.WithError(err).Error("failed to patch IPPool")
+			return err
 		}
 	}
 	err = waitForTigeraStatus(ctx, clients)
 	if err != nil {
-		return fmt.Errorf("error waiting for tigera status")
+		log.WithError(err).Error("error waiting for tigera status")
+		return err
 	}
 	return nil
 }
@@ -293,7 +314,8 @@ func patchInstallation(ctx context.Context, clients config.Clients, encap string
 	installation := &operatorv1.Installation{}
 	err := clients.CtrlClient.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, installation)
 	if err != nil {
-		return fmt.Errorf("failed to get installation")
+		log.WithError(err).Error("failed to get installation")
+		return err
 	}
 	log.Debug("installation is", installation)
 	installation.Spec.CalicoNetwork.IPPools[0].Encapsulation = v1encap

--- a/pkg/cluster/cluster_internal.go
+++ b/pkg/cluster/cluster_internal.go
@@ -16,6 +16,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -280,8 +281,7 @@ func updateEncap(ctx context.Context, cfg config.Config, clients config.Clients,
 	} else if encap == config.EncapUnset {
 		log.Info("No encapsulation specified, using whatever is already set")
 	} else {
-		log.WithError(err).Errorf("invalid encapsulation %s", encap)
-		return err
+		return fmt.Errorf("invalid encapsulation %s", encap)
 	}
 
 	if semver.Compare(cfg.CalicoVersion, "v3.28.0") < 0 {

--- a/pkg/iperf/iperf.go
+++ b/pkg/iperf/iperf.go
@@ -269,7 +269,7 @@ func DeployIperfPods(ctx context.Context, clients config.Clients, namespace stri
 	nodelist := &corev1.NodeList{}
 	err := clients.CtrlClient.List(ctx, nodelist)
 	if err != nil {
-		log.WithError(err).Error("failed to list nodes: %w", err)
+		log.WithError(err).Error("failed to list nodes")
 		return err
 	}
 	for _, node := range nodelist.Items {

--- a/pkg/iperf/iperf.go
+++ b/pkg/iperf/iperf.go
@@ -269,7 +269,8 @@ func DeployIperfPods(ctx context.Context, clients config.Clients, namespace stri
 	nodelist := &corev1.NodeList{}
 	err := clients.CtrlClient.List(ctx, nodelist)
 	if err != nil {
-		return fmt.Errorf("failed to list nodes: %w", err)
+		log.WithError(err).Error("failed to list nodes: %w", err)
+		return err
 	}
 	for _, node := range nodelist.Items {
 		if node.Labels["tigera.io/test-nodepool"] == "default-pool" {

--- a/pkg/qperf/qperf.go
+++ b/pkg/qperf/qperf.go
@@ -315,7 +315,8 @@ func DeployQperfPods(ctx context.Context, clients config.Clients, namespace stri
 	nodelist := &corev1.NodeList{}
 	err := clients.CtrlClient.List(ctx, nodelist)
 	if err != nil {
-		return fmt.Errorf("failed to list nodes: %w", err)
+		log.WithError(err).Error("failed to list nodes: %w", err)
+		return err
 	}
 	for _, node := range nodelist.Items {
 		if node.Labels["tigera.io/test-nodepool"] == "default-pool" {

--- a/pkg/qperf/qperf.go
+++ b/pkg/qperf/qperf.go
@@ -315,7 +315,7 @@ func DeployQperfPods(ctx context.Context, clients config.Clients, namespace stri
 	nodelist := &corev1.NodeList{}
 	err := clients.CtrlClient.List(ctx, nodelist)
 	if err != nil {
-		log.WithError(err).Error("failed to list nodes: %w", err)
+		log.WithError(err).Error("failed to list nodes")
 		return err
 	}
 	for _, node := range nodelist.Items {


### PR DESCRIPTION
In a number of places, we were doing something like:
```
if err != nil {
    return fmt.Error("some sort of error")
}
```
But this loses the vital information contained in `err`.  We should always log out `err` somehow, and usually pass err back to the calling function to make the output more useful for diagnosis.
