### PR TITLE
build qperf from source, use older version for compatibility with kernels without ipv6

### DIFF
--- a/images/perf/Dockerfile
+++ b/images/perf/Dockerfile
@@ -1,6 +1,25 @@
+FROM alpine:3.21 AS build-env
+RUN apk add --no-cache build-base git autoconf automake perl perl-doc
+
+# Version 0.4.11 requires ipv6, 0.4.10 does not support ipv6 at all.
+# To permit running on nodes where IPv6 is disabled in the kernel, we use 0.4.10.
+# We get versions by git hash for integrity reasons.
+# 0.4.11 = c706363815a38ff2c5cbc07b73e2cfaaa59bae0f
+# 0.4.10 = aa644b22fff9e939e549a9759629be58b3c5cac2
+RUN git clone --single-branch https://github.com/linux-rdma/qperf.git
+WORKDIR /qperf
+RUN git checkout aa644b22fff9e939e549a9759629be58b3c5cac2
+
+# Build qperf from source
+RUN ./cleanup && \
+    ./autogen.sh && \
+    ./configure && \
+    make
+
 FROM alpine:3.21
 
 RUN apk add --no-cache iperf3 curl tcpdump
-RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ qperf
+COPY --from=build-env /qperf/src/qperf /usr/bin/qperf
+RUN chmod +x /usr/bin/qperf
 
 USER perf


### PR DESCRIPTION
https://access.redhat.com/solutions/5353011 and https://github.com/linux-rdma/qperf/pull/25 indicate that qperf cannot run in an environment where ipv6 is disabled in the kernel by command line, causing it to error:
```
# qperf
    unable to bind to listen port
```
https://github.com/linux-rdma/qperf/pull/25 goes on to propose a fix for this. But the fix does not work.  Instead, we can roll back the version of qperf to before the commit which added IPv6 support.  0.4.11 requires ipv6, 0.4.10 does not support ipv6.

This PR replaces the qperf install from the alpine packages with building from source code at the pre-ipv6 version tag.