### PR TITLE
Ensure that TestPort is defaulted in Perf tests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -253,7 +253,7 @@ func defaultAndValidate(cfg *Config) error {
 		}
 		if tcfg.TestKind == "thruput-latency" || tcfg.TestKind == "iperf" {
 			if tcfg.Perf == nil {
-				tcfg.Perf = &PerfConfig{true, true, false, 32000, 0, ""} // Default so that old configs don't break
+				tcfg.Perf = &PerfConfig{true, true, false, 32000, 32001, ""} // Default so that old configs don't break
 				continue
 			}
 			if tcfg.Perf.External {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -139,6 +139,8 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, true, cfg.TestConfigs[0].Perf.Service)
 	assert.Equal(t, false, cfg.TestConfigs[0].Perf.External)
 	assert.Equal(t, "testns", cfg.TestConfigs[0].TestNamespace)
+	assert.Equal(t, 32000, cfg.TestConfigs[0].Perf.ControlPort)
+	assert.Equal(t, 32001, cfg.TestConfigs[0].Perf.TestPort)
 }
 
 func TestInvalidTestKind(t *testing.T) {


### PR DESCRIPTION
Previously, TestPort was being defaulted to `0`, which causes the tool to try to generate an invalid zzz-perf-test-policy.