### PR TITLE
Add ref input to checkout step in Build of images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Login to Docker registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Adds a ref parameter to the checkout step in the GitHub Actions workflow to ensure the correct commit SHA is checked out during the build process.