### PR TITLE
Harden CI workflow against pwn request attacks (release-v0.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 
 on:
   push:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 env:
@@ -14,14 +14,17 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
       - name: Setup Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Install dependencies
@@ -29,16 +32,17 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84  # v6
         with:
           version: v1.64.8
       - name: Test
         run: go test -v ./...
       - name: Run e2e test
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         run: make e2e-test
   deploy:
     needs: test
-    if: ${{ success() }} && github.event_name == 'push'
+    if: success() && github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -54,21 +58,21 @@ jobs:
             image: ${{ vars.REGISTRY }}/${{ vars.ORGANISATION }}/tiger-bench
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
       - name: Login to Docker registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ vars.REGISTRY }}
           username: ${{ vars.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ matrix.image }}
           tags: |
@@ -76,10 +80,10 @@ jobs:
             type=ref,event=pr
             type=semver,pattern=v{{version}}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build and push Docker images for tiger-bench
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}


### PR DESCRIPTION
## Summary

Backport of the CI hardening from #39 to `release-v0.6`.

- Replace `pull_request_target` with `pull_request` so fork PRs no longer run with access to secrets or a write-capable `GITHUB_TOKEN`
- Remove `safe to test` label gate; add explicit `permissions` blocks (`contents: read` + `checks: write` on `test`; `contents: read` on `deploy`)
- Remove unnecessary `packages: write` from `deploy` job
- Pin all actions to immutable commit SHAs to prevent supply chain attacks via tag force-push
- Gate e2e test to `push` and same-repo PRs only
- Add `persist-credentials: false` to both checkout steps
- Simplify checkout refs to `github.sha` and fix `deploy` job `if` condition syntax

Ref: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation

🤖 Generated with [Claude Code](https://claude.com/claude-code)