### PR TITLE
Default perf ports when the Perf block is partially specified

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -287,20 +287,32 @@ func defaultAndValidate(cfg *Config) error {
 				if tcfg.Perf.ExternalIPOrFQDN == "" {
 					return fmt.Errorf("ExternalIPOrFQDN is required for an external thruput-latency test")
 				}
-				if tcfg.TestKind == "thruput-latency" {
-					if tcfg.Perf.ControlPort == 0 {
-						return fmt.Errorf("ControlPort is required for an external thruput-latency test")
-					}
-					if tcfg.Perf.ControlPort > 65535 || tcfg.Perf.ControlPort < 1 {
-						return fmt.Errorf("ControlPort must be between 1 and 65535")
-					}
+
+				// External ports can't be defaulted. The test tools don't work through NAT, so
+				// these have to match the ports the service is actually exposed on.
+				if tcfg.TestKind == "thruput-latency" && tcfg.Perf.ControlPort == 0 {
+					return fmt.Errorf("ControlPort is required for an external thruput-latency test")
 				}
 				if tcfg.Perf.TestPort == 0 {
 					return fmt.Errorf("TestPort is required for an external thruput-latency test")
 				}
-				if tcfg.Perf.TestPort > 65535 || tcfg.Perf.TestPort < 1 {
-					return fmt.Errorf("TestPort must be between 1 and 65535")
+			} else {
+				// Default the ports per-field rather than only when Perf is absent entirely. A
+				// config that sets some of Perf but leaves the ports out otherwise reaches the
+				// dataplane with port 0, and the apiserver rejects the test policy.
+				if tcfg.Perf.ControlPort == 0 {
+					tcfg.Perf.ControlPort = 32000
 				}
+				if tcfg.Perf.TestPort == 0 {
+					tcfg.Perf.TestPort = 32001
+				}
+			}
+
+			if tcfg.TestKind == "thruput-latency" && (tcfg.Perf.ControlPort > 65535 || tcfg.Perf.ControlPort < 1) {
+				return fmt.Errorf("ControlPort must be between 1 and 65535")
+			}
+			if tcfg.Perf.TestPort > 65535 || tcfg.Perf.TestPort < 1 {
+				return fmt.Errorf("TestPort must be between 1 and 65535")
 			}
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -604,3 +604,62 @@ func TestTargetURLCustomValue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://custom.example.org", cfg.TestConfigs[0].DNSPerf.TargetURL)
 }
+
+func TestPerfPortsDefaultedWhenPerfPartiallySpecified(t *testing.T) {
+	fileContent := `
+- testKind: thruput-latency
+  Perf:
+    direct: true
+    service: true
+    external: false
+`
+	filePath := "/tmp/test_configs.yaml"
+	err := os.WriteFile(filePath, []byte(fileContent), 0o644)
+	require.NoError(t, err)
+	defer os.Remove(filePath)
+
+	var cfg Config
+	cfg.TestConfigFile = filePath
+	err = loadTestConfigsFromFile(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 32000, cfg.TestConfigs[0].Perf.ControlPort)
+	assert.Equal(t, 32001, cfg.TestConfigs[0].Perf.TestPort)
+}
+
+func TestPerfPortsStillRequiredForExternalTest(t *testing.T) {
+	fileContent := `
+- testKind: thruput-latency
+  Perf:
+    external: true
+    ExternalIPOrFQDN: perf.example.com
+`
+	filePath := "/tmp/test_configs.yaml"
+	err := os.WriteFile(filePath, []byte(fileContent), 0o644)
+	require.NoError(t, err)
+	defer os.Remove(filePath)
+
+	var cfg Config
+	cfg.TestConfigFile = filePath
+	err = loadTestConfigsFromFile(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ControlPort is required")
+}
+
+func TestPerfPortOutOfRangeRejectedForNonExternalTest(t *testing.T) {
+	fileContent := `
+- testKind: thruput-latency
+  Perf:
+    external: false
+    TestPort: 99999
+`
+	filePath := "/tmp/test_configs.yaml"
+	err := os.WriteFile(filePath, []byte(fileContent), 0o644)
+	require.NoError(t, err)
+	defer os.Remove(filePath)
+
+	var cfg Config
+	cfg.TestConfigFile = filePath
+	err = loadTestConfigsFromFile(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TestPort must be between 1 and 65535")
+}


### PR DESCRIPTION
A test config that supplies a `Perf` block without ports fails about 20 seconds into the run, when the apiserver rejects the test policy for having port 0. The defaults were only applied when `Perf` was missing entirely, so a block that set `direct`/`service` and nothing else left both ports at zero.

Ports are now defaulted per-field for non-external tests. External tests still require them explicitly, since the test tools don't work through NAT and the ports have to match whatever the service is exposed on.

The range checks moved out of the external-only branch too, so an out-of-range port is caught at config load instead of part way into a run.

Found while setting up an iptables/nftables comparison, where the config that triggered it was just `direct: true, service: true, external: false` - which is what the defaults already are.
